### PR TITLE
cukinia: bump cukinia version

### DIFF
--- a/recipes-support/cukinia/cukinia_git.bb
+++ b/recipes-support/cukinia/cukinia_git.bb
@@ -5,7 +5,8 @@ LICENSE = "Apache-2.0 | GPL-3.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
 SRC_URI = "git://github.com/savoirfairelinux/cukinia.git;branch=master"
-SRCREV = "c11f897af929121c98952b67f0cb56e16fa4bcca"
+SRCREV = "${AUTOREV}"
+PV = "master+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Bump cukinia version to 4ec72777f4a5f567c776983b6c89bea6bc91533a which
modifies cukinia_process function to rely on data from /proc rather than
ps output.