### PR TITLE
cukinia_git.bb: rdepends from bash

### DIFF
--- a/recipes-support/cukinia/cukinia_git.bb
+++ b/recipes-support/cukinia/cukinia_git.bb
@@ -10,6 +10,8 @@ PV = "master+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 
+RDEPENDS_${PN} += "bash"
+
 do_install () {
     install -d ${D}${bindir}
     install -m 0755 ${S}/cukinia ${D}${bindir}


### PR DESCRIPTION
Cukinia is a shell script so this recipe must depends from bash.
Otherwise if nothing else adds bash in the image, you will end with an
error like this:
  nothing provides /bin/sh needed by cukinia-master+git0+ea934c5393-r0.noarch