### PR TITLE
cukinia_git.bb: use https protocol

### DIFF
--- a/recipes-support/cukinia/cukinia_git.bb
+++ b/recipes-support/cukinia/cukinia_git.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/savoirfairelinux/cukinia"
 LICENSE = "Apache-2.0 | GPL-3.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
-SRC_URI = "git://github.com/savoirfairelinux/cukinia.git;branch=master"
+SRC_URI = "git://github.com/savoirfairelinux/cukinia.git;branch=master;protocol=https"
 SRCREV = "${AUTOREV}"
 PV = "master+git${SRCPV}"
 


### PR DESCRIPTION
GitHub has changed its security policies [1] and now forbid cloning
repositories through `git://` without authentication.
Thus, use `https` protocol to fetch cukinia sources.

[1]: https://github.blog/2021-09-01-improving-git-protocol-security-github/